### PR TITLE
Update citation info so citation("tr.iatgen") cites the paper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tr.iatgen
-Date: 2025-12-03
+Date: 2026-05-04
 Title: Translate 'iatgen' Generated QSF Files
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(
     person("Michal", "Kouril", , "Michal.Kouril@cchmc.org",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-4786-7934")),
@@ -9,8 +9,8 @@ Authors@R: c(
            role = c("aut"), comment = c(ORCID = "0000-0001-6640-126X")))
 Description: Automates translating the instructions of 'iatgen' generated qsf
              (Qualtrics survey files) to other languages using either officially
-             supported or user-supplied translations (for tutorial see Santos
-             et al., 2023 <doi:10.17504/protocols.io.kxygx34jdg8j/v1>).
+             supported or user-supplied translations (see Santos et al., 2026
+             <doi:10.1371/journal.pone.0342742>
 URL: https://github.com/iatgen/tr.iatgen
 BugReports: https://github.com/iatgen/tr.iatgen/issues
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tr.iatgen 1.1.4
+
+* Updated `inst/CITATION` to prioritize citing the associated paper (Santos et al., 2026, PLOS ONE) and protocol (Santos et al., 2024, protocols.io) before the R package itself.
+
 # tr.iatgen 1.1.2
 
 * Added examples in the vignette, pointing to

--- a/R/translate_qsf.R
+++ b/R/translate_qsf.R
@@ -9,12 +9,12 @@
 # 1. 'en' -> lang
 # 2. src_lang -> 'en' -> lang (optionaly provided either 'en' -> src_lang or 'en' -> lang)
 # 3. src_lang -> mid_lang -> 'en' -> lang (provided file src_lang -> mid_lang)
-# 4. src_lang -> 'en' -> mid_lang -> lang (provided file mid_lan -> lang)
+# 4. src_lang -> 'en' -> mid_lang -> lang (provided file mid_lang -> lang)
 #'
 #' @param file qsf file
 #' @param lang Target language (abbreviation).
 #' @param lang_file CSV file containing custom translation.
-#' @param src_lang Source language -- "en" for english is the only supported one.
+#' @param src_lang Source language -- "en" for English is the only supported one.
 #' @param dst_file save the translated file as. If NULL temporary file will be created.
 #'
 #' @return Translated file path/location (class: character)
@@ -60,7 +60,7 @@ translate.qsf <-
     )
 
     if (is.null(src_qsf_content)) {
-      return(NULL)
+      return(NULL) # not tested
     }
 
     # first check if we are provided with a custom language file
@@ -68,7 +68,7 @@ translate.qsf <-
       ret_lang <- validate.language(file = lang_file, src_lang = src_lang)
       if (is.null(ret_lang)) {
         stop("Invalid language file.")
-        return(NULL)
+        return(NULL) # not tested
       }
       inst <- tryCatch(
         {
@@ -83,13 +83,11 @@ translate.qsf <-
         (lang %in% ret_lang || lang %in% paste0("en", "_", ret_lang))
       ) {
         lang <- as.character(lang)
-      } else {
-        stop(
-          "Invalid `lang` or `src_lang` provided. Please check your custom translation file\n"
-        )
+      } else { # not tested
+        stop("Invalid `lang` or `src_lang` provided. Please check your custom translation file\n")
       }
 
-      # if there is no custom langugage file work with built-in translations
+      # if there is no custom language file work with built-in translations
     } else {
       available_translation_code <- available.languages()$Code
 
@@ -107,7 +105,7 @@ translate.qsf <-
       if (length(lang_arr) == 2) {
         lang <- lang_arr[2]
 
-        # FIXME: validate lang_arr[1]?
+        # FIXME: validate lang_arr[1]? (not tested)
       }
 
       builtin_lang_file <- file.path("langs", paste0(src_lang, "_", lang, ".csv"))
@@ -118,7 +116,7 @@ translate.qsf <-
         {
           read.csv(builtin_lang_file, check.names = FALSE)
         },
-        error = function(cond) {
+        error = function(cond) { # not tested
           message(paste("Unable to read builtin lang file:", builtin_lang_file))
           message("Here's the original error message:")
           message(cond)
@@ -132,14 +130,14 @@ translate.qsf <-
     }
 
     # now we have inst (mapping from src to dst language)
-    if (is.null(dst_file)) {
+    if (is.null(dst_file)) { # not tested
       dst_file <- tempfile(pattern = "file", tmpdir = tempdir(), fileext = ".qsf")
     }
 
     # Prepare for translation.
     from <- as.character(src_lang)
     src_qsf_content <- as.character(src_qsf_content)
-    if (!lang %in% colnames(inst)) {
+    if (!lang %in% colnames(inst)) { # not tested
       stop(
         paste(
           "The `to` language column name provided is not available in the translations file!\nPlease provide a valid language column name in the tr_iatgen() function call and try again.\n",
@@ -154,15 +152,15 @@ translate.qsf <-
 
       if (src_lang %in% colnames(inst)) {
         # src_lang and lang included go direct
-        for (i in seq_len(nrow(inst))) {
+        for (i in seq_len(nrow(inst))) { # not tested
           src_qsf_content <- gsub(inst[i, src_lang], inst[i, lang], src_qsf_content, fixed = TRUE)
         }
-      } else {
+      } else { # not tested
         # src_lang not included -- first see if we can "untranslate" to 'en'
       }
     } else {
       # src_lang is 'en'
-      if (!src_lang %in% colnames(inst)) {
+      if (!src_lang %in% colnames(inst)) { # not tested
         stop(
           "The `from` language column name provided is not available in the translations file!\nPlease provide a valid from language column name or none at all in the tr_iatgen() function call and try again.\n"
         )

--- a/R/translate_qsf_gui.R
+++ b/R/translate_qsf_gui.R
@@ -1,4 +1,4 @@
-#' @title Graphical user interface (GUI) to translate iatgen generate QSF file
+#' @title Graphical user interface (GUI) to translate iatgen generated QSF file
 #'
 #' @description
 #' This function allows you to translate an iatgen QSF file by visually

--- a/R/validate_language.R
+++ b/R/validate_language.R
@@ -5,8 +5,8 @@
 #' 2 columns and 28 rows:
 #' * the first column contains the english language text (as compared to the template file)
 #' * the second column contains the translation of the first column in a target language
-#' The first rows contains heading -- heading of the first column is "en" for English
-#' and the heading of the second colum is iana formatted target langugage specifier.
+#' The first row contains heading -- heading of the first column is "en" for English
+#' and the heading of the second column is iana formatted target language specifier.
 #'
 #' @param file Source CSV file to validate
 #' @param src_lang Source language -- "en" for english is the only supported one.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,50 @@
+citHeader("Please cite the following paper when using tr.iatgen:")
+
+bibentry(bibtype = "Article",
+  title = "Implicit association tests for all: Using iatgen for non-English and offline samples",
+  author = c(
+    as.person("João O. Santos"),
+    as.person("Emerson Do Bú"),
+    as.person("Tomohiro Hara"),
+    as.person("Cristina Mendonça"),
+    as.person("Sara Hagá"),
+    as.person("Ruth Pogacar"),
+    as.person("Michal Kouril")
+  ),
+  journal = "PLOS ONE",
+  year = "2026",
+  volume = "21",
+  number = "4",
+  pages = "1-8",
+  doi = "10.1371/journal.pone.0342742",
+  url = "https://doi.org/10.1371/journal.pone.0342742"
+)
+
+bibentry(bibtype = "Manual",
+  header = "The software was developed alongside the following protocol:",
+  title = "Generating Non-English IATs and Collecting Offline Samples",
+  author = c(
+    as.person("João O. Santos"),
+    as.person("Emerson Do Bú"),
+    as.person("Tomohiro Hara"),
+    as.person("Cristina Mendonça"),
+    as.person("Sara Hagá"),
+    as.person("Ruth Pogacar"),
+    as.person("Michal Kouril")
+  ),
+  journal = "protocols.io",
+  year = "2024",
+  month = "01",
+  doi = "10.17504/protocols.io.kxygx34jdg8j/v1",
+  url = "https://doi.org/10.17504/protocols.io.kxygx34jdg8j/v1"
+)
+
+bibentry(bibtype = "Manual",
+  header = "To cite the tr.iatgen package itself, use:",
+  title = "tr.iatgen: Translate 'iatgen' Generated QSF Files",
+  author = c(as.person("Michal Kouril"), as.person("João O. Santos")),
+  year = "2026",
+  note = "R package version 1.1.4",
+  url = "https://CRAN.R-project.org/package=tr.iatgen",
+  doi = "10.32614/CRAN.package.tr.iatgen"
+)

--- a/vignettes/translating-iatgen-qsf.Rmd
+++ b/vignettes/translating-iatgen-qsf.Rmd
@@ -22,8 +22,10 @@ generated qsf (Qualtrics survey files) to other languages using either
 officially supported or user-supplied translations.
 
 In this vignette we present some examples of how to use the functions
-provided by this pacakge. For a comprehensive tutorial see [Santos and
-collaborators (2023)](https://doi.org/10.17504/protocols.io.kxygx34jdg8j/v1).
+provided by this package. For the original paper see [Santos and
+collaborators (2026)](https://doi.org/10.1371/journal.pone.0342742),
+for a comprehensive tutorial see
+[Santos and collaborators (2023)](https://doi.org/10.17504/protocols.io.kxygx34jdg8j/v1).
 
 
 ``` {r, eval = FALSE}


### PR DESCRIPTION
- Added a custom inst/CITATION asking users to cite the PLOS ONE paper, adding the ref for the protocol, and keeping the citation for the package itself

- also made some typo fixes and included comments in translate_qsf() with the lines with no test coverage (they mostly have to do with testing failed file reads). The shiny code is also not tested, but that can be fixed later.

P.S: translate_qsf.R still has a few FIXME opened...